### PR TITLE
remove usage of postgresql ensurePermissions

### DIFF
--- a/piped-backend/module.nix
+++ b/piped-backend/module.nix
@@ -166,9 +166,7 @@ in
       ensureDatabases = lib.singleton cfg.dbName;
       ensureUsers = lib.singleton {
         name = cfg.settings."hibernate.connection.username";
-        ensurePermissions = {
-          "DATABASE ${cfg.dbName}" = "ALL PRIVILEGES";
-        };
+        ensureDBOwnership = cfg.dbName == cfg.settings."hibernate.connection.username";
       };
     };
 

--- a/piped-backend/test.nix
+++ b/piped-backend/test.nix
@@ -25,9 +25,6 @@ in
       services.postgresql = {
         initialScript = pkgs.writeText "init-postgres-with-password" ''
           CREATE USER piped WITH PASSWORD 'piped';
-          CREATE DATABASE piped;
-          GRANT ALL PRIVILEGES ON DATABASE piped TO piped;
-          ALTER DATABASE piped OWNER TO piped;
         '';
       };
     };

--- a/piped-test/default.nix
+++ b/piped-test/default.nix
@@ -53,9 +53,6 @@ in
       services.postgresql = {
         initialScript = pkgs.writeText "init-postgres-with-password" ''
           CREATE USER piped WITH PASSWORD 'piped';
-          CREATE DATABASE piped;
-          GRANT ALL PRIVILEGES ON DATABASE piped TO piped;
-          ALTER DATABASE piped OWNER TO piped;
         '';
       };
     };


### PR DESCRIPTION
this has been removed for NixOS 24.05.

Instead use `ensureDBOwnership` when possible.